### PR TITLE
feat(action): bump Ren'Py CLI version from 8.2.1 to 8.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [7.7.1, 8.2.1]
+        version: [7.7.1, 8.3.0]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ See [action.yml](action.yml)
 
 ### `cli-version`
 
-**Optional**: CLI [version](https://www.renpy.org/release_list.html). Defaults to [`8.2.1`](https://www.renpy.org/latest.html):
+**Optional**: CLI [version](https://www.renpy.org/release_list.html). Defaults to [`8.3.0`](https://www.renpy.org/latest.html):
 
 ```yaml
 - uses: remarkablegames/setup-renpy@v1
   with:
-    cli-version: 8.2.1
+    cli-version: 8.3.0
 
 - run: renpy-cli --version
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   cli-version:
     description: CLI version
     required: false
-    default: 8.2.1
+    default: 8.3.0
   launcher-name:
     description: Launcher name
     required: false


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(action): bump Ren'Py CLI version from 8.2.1 to 8.3.0

https://www.renpy.org/release/8.3.0

## What is the current behavior?

Ren'Py CLI version defaults to `8.2.1`

## What is the new behavior?

Ren'Py CLI version defaults to `8.3.0`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [x] Documentation