### PR TITLE
fix(action): downgrade Ren'Py CLI version from 8.3.0 to 8.2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        version: [7.7.1, 8.3.0]
+        version: [7.7.1, 8.2.3]
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ See [action.yml](action.yml)
 
 ### `cli-version`
 
-**Optional**: CLI [version](https://www.renpy.org/release_list.html). Defaults to [`8.3.0`](https://www.renpy.org/latest.html):
+**Optional**: CLI [version](https://www.renpy.org/release_list.html). Defaults to [`8.2.3`](https://www.renpy.org/release/8.2.3):
 
 ```yaml
 - uses: remarkablegames/setup-renpy@v1
   with:
-    cli-version: 8.3.0
+    cli-version: 8.2.3
 
 - run: renpy-cli --version
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   cli-version:
     description: CLI version
     required: false
-    default: 8.3.0
+    default: 8.2.3
   launcher-name:
     description: Launcher name
     required: false


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(action): downgrade Ren'Py CLI version from 8.3.0 to 8.2.3

## What is the current behavior?

Ren'Py version `8.3.0` has a bug with the web build: https://github.com/renpy/renpy/issues/5725

## What is the new behavior?

Ren'Py version defaults to `8.2.3`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation