### PR TITLE
fix: revert "build(deps): bump renpy from 8.3.7 to 8.4.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ See [action.yml](action.yml)
 
 ### `cli-version`
 
-**Optional**: CLI [version](https://www.renpy.org/release_list.html). Defaults to [`8.4.0`](https://www.renpy.org/release/8.4.0):
+**Optional**: CLI [version](https://www.renpy.org/release_list.html). Defaults to [`8.3.7`](https://www.renpy.org/release/8.3.7):
 
 ```yaml
 - uses: remarkablegames/setup-renpy@v1
   with:
-    cli-version: 8.4.0
+    cli-version: 8.3.7
 
 - run: renpy-cli --version
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   cli-version:
     description: CLI version
     required: false
-    default: 8.4.0
+    default: 8.3.7
   launcher-name:
     description: Launcher name
     required: false


### PR DESCRIPTION
Reverts remarkablegames/setup-renpy#352

See https://github.com/renpy/renpy/issues/6515